### PR TITLE
Mongodb Compass setup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,10 @@ services:
     env_file:
       - $CC_CONFIG_PATH/prod/global
     restart: unless-stopped
+    ports:
+      - 27017:27017
+    command: >
+      mongod --config $CC_CONFIG_PATH/prod/mongod.conf
 
   gateway:
     image: cc-gateway:latest

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -15,6 +15,10 @@ services:
     env_file:
       - $CC_CONFIG_PATH/staging/global
     restart: unless-stopped
+    ports:
+      - 27017:27017
+    command: >
+      mongod --config $CC_CONFIG_PATH/prod/mongod.conf
 
   gateway:
     image: cc-gateway:latest


### PR DESCRIPTION
## About

- This PR has been long due, its time to either do this or drop this completely.
- This PR requires a lot of changes and testing in the server side, (prolly staging).
- Basically the aim is to be able to securely (TLS) connect to production compass with some sort of certificate verification.

## Changes

- Changes the docker-compose.prod

## Todo

- We need to make a custom mongod.conf configuration which can have detailed tls setup info, along with pem file location. A sample is given below:
```
net:
  port: 27017
  bindIp: 0.0.0.0
  tls:
    mode: requireTLS
    certificateKeyFile: /etc/ssl/mongodb.pem
    CAFile: /etc/ssl/ca.pem # Optional, if client certificate validation is required
```
- We also require both client side and server-side certs, to be generated using command such as this:
```
openssl req -newkey rsa:2048 -nodes -keyout mongodb.key -x509 -days 365 -out mongodb.crt
cat mongodb.crt mongodb.key > mongodb.pem
```